### PR TITLE
Allow sending local data tables for SourceTV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 msvc12
+.vs/

--- a/extension/extension.cpp
+++ b/extension/extension.cpp
@@ -254,10 +254,9 @@ DETOUR_DECL_STATIC5(Handler_SendProxy_SendLocalDataTable, void*, const SendProp*
 	// We call the original function so as not to add a signature for function 'CSendProxyRecipients::SetOnly'.
 	DETOUR_STATIC_CALL(Handler_SendProxy_SendLocalDataTable)(pProp, pStruct, pVarData, pRecipients, objectID);
 
-	int iSTVSlotIndex = g_pHLTVServer->GetHLTVSlot();
-	CBasePlayer* pPlayer = UTIL_HLTVPlayerByIndex(iSTVSlotIndex + 1);
-	if (pPlayer != NULL) {
-		pRecipients->SetRecipient(iSTVSlotIndex);
+	int hltvSlotIndex = g_pHLTVServer->GetHLTVSlot();
+	if (hltvSlotIndex != 0) {
+		pRecipients->SetRecipient(hltvSlotIndex);
 	}
 
 	return (void*)pVarData;
@@ -384,13 +383,11 @@ void SMExtension::Unload()
 bool SMExtension::SetupFromGameConfig(IGameConfig* gc, char* error, int maxlength)
 {
 	// Unable to create unique signature for game left4dead and platform windows
-#if SOURCE_ENGINE == SE_LEFT4DEAD && defined _WIN32
 	if (!gc->GetAddress("SendProxy_SendLocalDataTable", (void**)&pfn_SendProxy_SendLocalDataTable) || !pfn_SendProxy_SendLocalDataTable) {
 		ke::SafeSprintf(error, maxlength, "Failed to get address of function \"SendProxy_SendLocalDataTable\" from game config (file: \"" GAMEDATA_FILE ".txt\")");
 	
 		return false;
 	}
-#endif
 
 	static const struct {
 		const char* key;
@@ -431,9 +428,6 @@ bool SMExtension::SetupFromGameConfig(IGameConfig* gc, char* error, int maxlengt
 		{ "CSteam3Server::NotifyClientDisconnect", CSteam3Server::pfn_NotifyClientDisconnect },
 		{ "CHLTVServer::AddNewFrame", CHLTVServer::pfn_AddNewFrame },
 		{ "CFrameSnapshotManager::LevelChanged", CFrameSnapshotManager::pfn_LevelChanged },
-#if SOURCE_ENGINE != SE_LEFT4DEAD || !defined _WIN32
-		{ "SendProxy_SendLocalDataTable", pfn_SendProxy_SendLocalDataTable },
-#endif
 #if SOURCE_ENGINE == SE_LEFT4DEAD2
 		{ "CBaseClient::SendFullConnectEvent", CBaseClient::pfn_SendFullConnectEvent },
 #endif

--- a/extension/extension.cpp
+++ b/extension/extension.cpp
@@ -13,6 +13,7 @@
 // Interfaces
 INetworkStringTableContainer* networkStringTableContainerServer = NULL;
 IHLTVDirector* hltvdirector = NULL;
+IHLTVServer* g_pHLTVServer = NULL;
 INetSupport* g_pNetSupport = NULL;
 IPlayerInfoManager* playerinfomanager = NULL;
 IServerGameEnts* gameents = NULL;
@@ -64,9 +65,13 @@ void* pfn_SteamGameServer_GetHSteamPipe = NULL;
 void* pfn_SteamGameServer_GetHSteamUser = NULL;
 void* pfn_SteamInternal_CreateInterface = NULL;
 void* pfn_SteamInternal_GameServer_Init = NULL;
+void* pfn_SendProxy_SendLocalDataTable = NULL;
 void* pfn_OpenSocketInternal = NULL;
 
 CDetour* detour_SteamInternal_GameServer_Init = NULL;
+CDetour* detour_SendProxy_SendLocalDataTable = NULL;
+
+void Cvar_SourceTVSendLocalTables_Changed(IConVar* pVar, const char* pOldValue, float flOldValue);
 
 // SourceHook
 SH_DECL_HOOK1_void(IHLTVDirector, SetHLTVServer, SH_NOATTRIB, 0, IHLTVServer*);
@@ -201,7 +206,62 @@ DETOUR_DECL_MEMBER0(Handler_CFrameSnapshotManager_LevelChanged, void)
 	// CFrameSnapshotManager::m_PackedEntitiesPool shouldn't have elements to free from now on
 	DETOUR_MEMBER_CALL(Handler_CFrameSnapshotManager_LevelChanged)();
 }
-//
+
+// @A1m`:
+// Similar code is in cs go.
+// This code is probably useless without a fix for the client.
+// Include the SourceTV client in the recipients for local data.
+// Code added to extension 'sourcetvsupport-client' (SourceTV client fixes).
+// When this cvar is disabled 'tv_send_local_tables', netprops from table 'localdata' will also be unavailable on the demo.
+// 
+// Left4Dead and Left4Dead2 game code
+/*void* SendProxy_SendLocalDataTable(const SendProp* pProp, const void* pStruct,
+										const void* pVarData, CSendProxyRecipients* pRecipients, int objectID)
+{
+	pRecipients->SetOnly(objectID - 1);
+
+	return (void*)pVarData;
+}*/
+
+ConVar g_CvarSourceTVSendLocalTables("tv_send_local_data_tables", \
+	"0", \
+	FCVAR_REPLICATED | FCVAR_DEMO, \
+	"Send local data table to SourceTV? Table contains local netprops owned by one player. Useless without 'sourcetvsupport-client'.", \
+	Cvar_SourceTVSendLocalTables_Changed \
+);
+
+void Cvar_SourceTVSendLocalTables_Changed(IConVar* pVar, const char* pOldValue, float flOldValue)
+{
+	if (!g_pHLTVServer) {
+		Msg("IHLTVServer not available, this feature cannot be activated now.""\n");
+
+		return;
+	}
+
+	// Checks for re-enable and re-disable are inside class 'CDetour'
+	if (g_CvarSourceTVSendLocalTables.GetBool()) {
+		detour_SendProxy_SendLocalDataTable->EnableDetour();
+
+		return;
+	}
+
+	detour_SendProxy_SendLocalDataTable->DisableDetour();
+}
+
+DETOUR_DECL_STATIC5(Handler_SendProxy_SendLocalDataTable, void*, const SendProp*, pProp, const void*, pStruct, \
+						const void*, pVarData, CSendProxyRecipientsWrapper*, pRecipients, int, objectID)
+{
+	// We call the original function so as not to add a signature for function 'CSendProxyRecipients::SetOnly'.
+	DETOUR_STATIC_CALL(Handler_SendProxy_SendLocalDataTable)(pProp, pStruct, pVarData, pRecipients, objectID);
+
+	int iSTVSlotIndex = g_pHLTVServer->GetHLTVSlot();
+	CBasePlayer* pPlayer = UTIL_HLTVPlayerByIndex(iSTVSlotIndex + 1);
+	if (pPlayer != NULL) {
+		pRecipients->SetRecipient(iSTVSlotIndex);
+	}
+
+	return (void*)pVarData;
+}
 
 // SMExtension
 void SMExtension::Load()
@@ -241,6 +301,7 @@ void SMExtension::Load()
 	CSteam3Server::detour_NotifyClientDisconnect->EnableDetour();
 	CHLTVServer::detour_AddNewFrame->EnableDetour();
 	CFrameSnapshotManager::detour_LevelChanged->EnableDetour();
+
 #if SOURCE_ENGINE == SE_LEFT4DEAD2
 	detour_SteamInternal_GameServer_Init->EnableDetour();
 	CBaseClient::detour_SendFullConnectEvent->EnableDetour();
@@ -249,6 +310,7 @@ void SMExtension::Load()
 #if SOURCE_ENGINE == SE_LEFT4DEAD
 	CGameServer::shookid_IsPausable = SH_ADD_HOOK(IServer, IsPausable, g_pGameIServer, SH_MEMBER(this, &SMExtension::Handler_CGameServer_IsPausable), true);
 #endif
+
 	SH_ADD_HOOK(IHLTVDirector, SetHLTVServer, hltvdirector, SH_MEMBER(this, &SMExtension::Handler_CHLTVDirector_SetHLTVServer), true);
 
 	OnSetHLTVServer(hltvdirector->GetHLTVServer());
@@ -295,6 +357,11 @@ void SMExtension::Unload()
 		detour_SteamInternal_GameServer_Init = NULL;
 	}
 
+	if (detour_SendProxy_SendLocalDataTable != NULL) {
+		detour_SendProxy_SendLocalDataTable->Destroy();
+		detour_SendProxy_SendLocalDataTable = NULL;
+	}
+
 	if (CSteam3Server::detour_NotifyClientDisconnect != NULL) {
 		CSteam3Server::detour_NotifyClientDisconnect->Destroy();
 		CSteam3Server::detour_NotifyClientDisconnect = NULL;
@@ -316,6 +383,15 @@ void SMExtension::Unload()
 
 bool SMExtension::SetupFromGameConfig(IGameConfig* gc, char* error, int maxlength)
 {
+	// Unable to create unique signature for game left4dead and platform windows
+#if SOURCE_ENGINE == SE_LEFT4DEAD && defined _WIN32
+	if (!gc->GetAddress("SendProxy_SendLocalDataTable", (void**)&pfn_SendProxy_SendLocalDataTable) || !pfn_SendProxy_SendLocalDataTable) {
+		ke::SafeSprintf(error, maxlength, "Failed to get address of function \"SendProxy_SendLocalDataTable\" from game config (file: \"" GAMEDATA_FILE ".txt\")");
+	
+		return false;
+	}
+#endif
+
 	static const struct {
 		const char* key;
 		int& offset;
@@ -355,6 +431,9 @@ bool SMExtension::SetupFromGameConfig(IGameConfig* gc, char* error, int maxlengt
 		{ "CSteam3Server::NotifyClientDisconnect", CSteam3Server::pfn_NotifyClientDisconnect },
 		{ "CHLTVServer::AddNewFrame", CHLTVServer::pfn_AddNewFrame },
 		{ "CFrameSnapshotManager::LevelChanged", CFrameSnapshotManager::pfn_LevelChanged },
+#if SOURCE_ENGINE != SE_LEFT4DEAD || !defined _WIN32
+		{ "SendProxy_SendLocalDataTable", pfn_SendProxy_SendLocalDataTable },
+#endif
 #if SOURCE_ENGINE == SE_LEFT4DEAD2
 		{ "CBaseClient::SendFullConnectEvent", CBaseClient::pfn_SendFullConnectEvent },
 #endif
@@ -437,6 +516,13 @@ bool SMExtension::CreateDetours(char* error, size_t maxlength)
 		return false;
 	}
 #endif
+
+	detour_SendProxy_SendLocalDataTable = DETOUR_CREATE_STATIC(Handler_SendProxy_SendLocalDataTable, pfn_SendProxy_SendLocalDataTable);
+	if (detour_SendProxy_SendLocalDataTable == NULL) {
+		ke::SafeStrcpy(error, maxlength, "Unable to create a detour for \"SendProxy_SendLocalDataTable\"");
+
+		return false;
+	}
 
 	CBaseServer::detour_IsExclusiveToLobbyConnections = DETOUR_CREATE_MEMBER(Handler_CBaseServer_IsExclusiveToLobbyConnections, CBaseServer::pfn_IsExclusiveToLobbyConnections);
 	if (CBaseServer::detour_IsExclusiveToLobbyConnections == NULL) {
@@ -568,6 +654,12 @@ void SMExtension::OnSetHLTVServer(IHLTVServer* pIHLTVServer)
 	// client doesn't allow stringTableCRC to be empty
 	// CHLTVServer instance must copy property stringTableCRC from CGameServer instance
 	pServer->stringTableCRC() = CBaseServer::FromIServer(g_pGameIServer)->stringTableCRC();
+
+	g_pHLTVServer = pIHLTVServer;
+
+	if (g_CvarSourceTVSendLocalTables.GetBool()) {
+		detour_SendProxy_SendLocalDataTable->EnableDetour();
+	}
 }
 
 void SMExtension::Handler_CHLTVDirector_SetHLTVServer(IHLTVServer* pIHLTVServer)
@@ -809,12 +901,16 @@ bool SMExtension::SDK_OnLoad(char* error, size_t maxlength, bool late)
 	sharesys->AddDependency(myself, "bintools.ext", true, true);
 	sharesys->AddDependency(myself, "sdktools.ext", true, true);
 
+	ConVar_Register(0, this);
+
 	return true;
 }
 
 void SMExtension::SDK_OnUnload()
 {
 	Unload();
+
+	ConVar_Unregister();
 }
 
 void SMExtension::SDK_OnAllLoaded()
@@ -833,6 +929,7 @@ bool SMExtension::SDK_OnMetamodLoad(ISmmAPI* ismm, char* error, size_t maxlen, b
 	GET_V_IFACE_CURRENT(GetEngineFactory, g_pNetSupport, INetSupport, INETSUPPORT_VERSION_STRING);
 
 	GET_V_IFACE_CURRENT(GetServerFactory, hltvdirector, IHLTVDirector, INTERFACEVERSION_HLTVDIRECTOR);
+
 	GET_V_IFACE_CURRENT(GetServerFactory, playerinfomanager, IPlayerInfoManager, INTERFACEVERSION_PLAYERINFOMANAGER);
 	GET_V_IFACE_CURRENT(GetServerFactory, gameents, IServerGameEnts, INTERFACEVERSION_SERVERGAMEENTS);
 
@@ -871,4 +968,10 @@ bool SMExtension::QueryRunning(char* error, size_t maxlength)
 	SM_CHECK_IFACE(BINTOOLS, bintools);
 
 	return true;
+}
+
+bool SMExtension::RegisterConCommandBase(ConCommandBase* pVar)
+{
+	// Notify metamod of ownership
+	return META_REGCVAR(pVar);
 }

--- a/extension/extension.h
+++ b/extension/extension.h
@@ -52,7 +52,8 @@ class IClient;
 #define PORT_SERVER			27015	// Default server port, UDP/TCP
 
 class SMExtension :
-	public SDKExtension
+	public SDKExtension,
+	public IConCommandBaseAccessor
 {
 public:
 	void Load();
@@ -149,6 +150,9 @@ public: // IExtensionInterface
 	 * @return					True on success, false otherwise.
 	 */
 	bool QueryRunning(char* error, size_t maxlength) override;
+
+public: // IConCommandBaseAccessor
+	bool RegisterConCommandBase(ConCommandBase* pVar) override;
 };
 
 #endif // _INCLUDE_SOURCETV_SUPPORT_H_

--- a/extension/smsdk_config.h
+++ b/extension/smsdk_config.h
@@ -4,7 +4,7 @@
 // Configuration
 #define SMEXT_CONF_NAME			"SourceTV Support"
 #define SMEXT_CONF_DESCRIPTION	"Restores broadcasting/recording SourceTV features in Left 4 Dead engine"
-#define SMEXT_CONF_VERSION		"0.10.1"
+#define SMEXT_CONF_VERSION		"0.10.3"
 #define SMEXT_CONF_AUTHOR		"Evgeniy \"shqke\" Kazakov"
 #define SMEXT_CONF_URL			"https://github.com/shqke/sourcetvsupport"
 #define SMEXT_CONF_LOGTAG		"STVS"

--- a/extension/wrappers.h
+++ b/extension/wrappers.h
@@ -324,37 +324,20 @@ public:
 class CSendProxyRecipientsWrapper
 {
 public:
-	inline void SetRecipient(int iClient)
+	inline void SetRecipient(int slotIndex)
 	{
-		m_Bits.Set(iClient);
+		m_Bits.Set(slotIndex);
 	}
 
 public:
 	CPlayerBitVec m_Bits; // Offset 0
 };
 
-CBasePlayer* UTIL_PlayerByIndex(int iPlayerIndex)
+CBasePlayer* UTIL_PlayerByIndex(int playerIndex)
 {
-	if (iPlayerIndex < 1 || iPlayerIndex > playerhelpers->GetMaxClients()) {
-		return NULL;
-	}
-
-	IGamePlayer* pGamePlayer = playerhelpers->GetGamePlayer(iPlayerIndex);
+	// SourceMod checks player index in function 'CPlayer *PlayerManager::GetPlayerByIndex(int client) const'
+	IGamePlayer* pGamePlayer = playerhelpers->GetGamePlayer(playerIndex);
 	if (!pGamePlayer) {
-		return NULL;
-	}
-
-	return (CBasePlayer*)gameents->EdictToBaseEntity(pGamePlayer->GetEdict());
-}
-
-CBasePlayer* UTIL_HLTVPlayerByIndex(int iPlayerIndex)
-{
-	if (iPlayerIndex < 1 || iPlayerIndex > playerhelpers->GetMaxClients()) {
-		return NULL;
-	}
-
-	IGamePlayer* pGamePlayer = playerhelpers->GetGamePlayer(iPlayerIndex);
-	if (!pGamePlayer || !pGamePlayer->IsSourceTV()) {
 		return NULL;
 	}
 

--- a/extension/wrappers.h
+++ b/extension/wrappers.h
@@ -34,7 +34,7 @@ extern IPlayerInfoManager* playerinfomanager;
 
 class CDetour;
 
-typedef CBitVec<32> CDWordBitVec; // 32 for l4d2
+typedef CBitVec<32> CDWordBitVec; // 32 for l4d2 and l4d1
 
 #define CPlayerBitVec CDWordBitVec
 

--- a/extra/sourcetvsupport.txt
+++ b/extra/sourcetvsupport.txt
@@ -43,6 +43,12 @@
 		
 		"Signatures"
 		{
+			"SendProxy_SendLocalDataTable"
+			{
+				"library"	"server"
+				"linux"		"@_Z28SendProxy_SendLocalDataTablePK8SendPropPKvS3_P20CSendProxyRecipientsi"
+			}
+
 			"DataTable_WriteSendTablesBuffer"
 			{
 				"library"	"engine"
@@ -89,6 +95,18 @@
 
 	"left4dead"
 	{
+		"Addresses"
+		{
+			"SendProxy_SendLocalDataTable"
+			{
+				"windows"
+				{
+					"signature"		"SendProxy_SendLocalDataTable"
+					"offset"		"16" // Offset 16 (+ 16 bytes)
+				}
+			}
+		}
+
 		"Offsets"
 		{
 			"CBaseServer::GetChallengeNr"
@@ -118,6 +136,20 @@
 		
 		"Signatures"
 		{
+			"SendProxy_SendLocalDataTable"
+			{
+				"library"	"server"
+				// Can be found by line "terrorlocaldata"
+				// Example: sub_1008F060(&unk_10650448, "terrorlocaldata", 0, &unk_1064C000, sub_1012B780);
+				// sub_1012B780 - the function we want
+				//
+				// It is not possible to create a unique signature in l4d1, 
+				// we use the bytes from the function that is in front, 
+				// we need to make an offset to get the correct address of the function we need.
+				// 89 0A C3 CC CC CC CC CC CC CC CC CC CC CC CC CC 8B 44 24 ?? 8B 4C 24 ?? 83 C0 FF 50 E8 ?? ?? ?? ?? 8B 44 24 ?? C3
+				"windows"	"\x89\x0A\xC3\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xCC\x8B\x44\x24\x2A\x8B\x4C\x24\x2A\x83\xC0\xFF\x50\xE8\x2A\x2A\x2A\x2A\x8B\x44\x24\x2A\xC3"
+			}
+
 			"DataTable_WriteSendTablesBuffer"
 			{
 				"library"	"engine"
@@ -205,6 +237,17 @@
 		
 		"Signatures"
 		{
+			"SendProxy_SendLocalDataTable"
+			{
+				"library"	"server"
+				// Can be found by line "terrorlocaldata"
+				// Example: sub_100A7C30(&unk_108561E8, "terrorlocaldata", 0, &unk_10851480, sub_1016A8C0, 0x80);
+				// sub_1016A8C0 - the function we want
+				//
+				// 55 8B EC 8B 45 ? 8B 4D ? 48 50 E8 ? ? ? ? 8B 45 ? 5D C3 ? ? ? ? ? ? ? ? ? ? ? 55
+				"windows"	"\x55\x8B\xEC\x8B\x45\x2A\x8B\x4D\x2A\x48\x50\xE8\x2A\x2A\x2A\x2A\x8B\x45\x2A\x5D\xC3\x2A\x2A\x2A\x2A\x2A\x2A\x2A\x2A\x2A\x2A\x2A\x55"
+			}
+
 			"DataTable_WriteSendTablesBuffer"
 			{
 				"library"	"engine"

--- a/extra/sourcetvsupport.txt
+++ b/extra/sourcetvsupport.txt
@@ -2,6 +2,17 @@
 {
 	"#default"
 	{
+		"Addresses"
+		{
+			"SendProxy_SendLocalDataTable"
+			{
+				"linux"
+				{
+					"signature"	"SendProxy_SendLocalDataTable"
+				}
+			}
+		}
+
 		"Offsets"
 		{
 			"CBaseServer::stringTableCRC"
@@ -101,8 +112,8 @@
 			{
 				"windows"
 				{
-					"signature"		"SendProxy_SendLocalDataTable"
-					"offset"		"16" // Offset 16 (+ 16 bytes)
+					"signature"	"SendProxy_SendLocalDataTable"
+					"offset"	"16" // Offset 16 (+ 16 bytes)
 				}
 			}
 		}
@@ -196,6 +207,17 @@
 
 	"left4dead2"
 	{
+		"Addresses"
+		{
+			"SendProxy_SendLocalDataTable"
+			{
+				"windows"
+				{
+					"signature"	"SendProxy_SendLocalDataTable"
+				}
+			}
+		}
+
 		"Offsets"
 		{
 			"CBaseServer::GetChallengeNr"


### PR DESCRIPTION
This code is probably useless without a fix for the client. This code added for vsp `sourcetvsupport-client` (SourceTV client fixes). If we add a fix for the client, apply netprop `C_BasePlayer::m_Local.m_vecPunchAngle`, then a lot of effects related to the camera are displayed, these effects are not available to ordinary spectators. For example, the camera shakes in such cases if the player shoots, there is recoil if the player is knocked down, if the player jumps, if a teammate shoots the player, and so on. Related issues: A1mDev/sourcetvsupport-client#4, A1mDev/sourcetvsupport-client#2, #35. The game developers did not add SourceTV support for games l4d2 and l4d1, so all netprops from local tables are not used for the view behind another player. These netprops are only available to the local player.

Convar `tv_send_local_data_tables` will enable this feature, by default the feature is disabled, in the demo these netprops will also be unavailable when the feature is disabled.